### PR TITLE
Add quic support

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,28 @@ const createServer = (aedes, options = {}) => {
       stream._socket = conn._socket
       bindConnection(aedes, options, stream, req)
     })
+
+  } else if (options.quic) {
+
+    const { createQuicSocket } = require('net')
+
+    server = createQuicSocket({
+      endpoint: { port: options.quic.port || 8885 }, // default port 8885 if not mentioned in options
+      server: {
+        key: options.quic.key,
+        cert: options.quic.cert,
+        alpn: options.quic.alpn || 'mqtt'
+      }
+    })
+
+    server.on('session', (session) => {
+      session.on('stream', (stream) => {
+        stream.socket = session.socket
+        bindConnection(aedes, options, stream)
+      })
+
+    })
+
   } else {
     server = net.createServer((conn) => {
       bindConnection(aedes, options, conn)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,7 @@ export interface ServerFactoryOptions {
   http2?: Http2ServerOptions;
   tls?: TlsOptions;
   tcp?: { allowHalfOpen?: boolean; pauseOnConnect?: boolean };
+  quic?:{ port?: number; key: ArrayBuffer; cert: ArrayBuffer; alpn: string};
   serverFactory?: ServerFactory;
   protocolDecoder?: ProtocolDecoder;
   extractSocketDetails?: ExtractSocketDetails;


### PR DESCRIPTION
Added support for QUIC protocol through the core QUIC module of NodeJS (v15 - pre)

[NodeJS QUIC Documentation](https://nodejs.org/dist/v15.7.0/docs/api/quic.html)